### PR TITLE
nagios4: fix Apache2 authentication realm

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ None
 * `nagios_server_htpasswd_users.{n}.name`: [required]: Username
 * `nagios_server_htpasswd_users.{n}.password`: [required]: Password
 
+* `nagios_server_htdigest_realm`: [optional, default `Nagios4`]: Apache2 digest authentication realm (Nagios 4 only)
+
 * `nagios_server_cgi`: [default: `{}`]: CGI declarations
 * `nagios_server_cgi.refresh_rate`: [optional, default: `90`]: Refresh rate
 * `nagios_server_cgi.result_limit`: [optional, default: `100`]: Default page limit

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 # defaults file
 ---
 nagios_server_htpasswd_users: []
+nagios_server_htdigest_realm: 'Nagios4'
 
 nagios_server_private_keys: []
 

--- a/templates/etc/nagios4/apache2.conf.j2
+++ b/templates/etc/nagios4/apache2.conf.j2
@@ -25,7 +25,7 @@ Alias /nagios4 /usr/share/nagios4/htdocs
     AuthDigestDomain "Nagios4"
     AuthDigestProvider file
     AuthUserFile "/etc/nagios4/htdigest.users"
-    AuthName "Nagios4"
+    AuthName "{{ nagios_server_htdigest_realm }}"
     AuthType Digest
     Require valid-user
 </DirectoryMatch>

--- a/templates/etc/nagios4/htdigest.users.j2
+++ b/templates/etc/nagios4/htdigest.users.j2
@@ -1,4 +1,4 @@
-{% set realm = 'Nagios Access' -%}
+{% set realm = nagios_server_htdigest_realm -%}
 {% for item in nagios_server_htpasswd_users %}
 {{ item.name }}:{{ realm }}:{{ (item.name ~ ':' ~ realm ~ ':' ~ item.password) | hash('md5') }}
 {% endfor %}


### PR DESCRIPTION
AuthName directive of Apache2 authentication module sets the
the authorization realm for a directory. This needs to match
the realm set in AuthUserFile for digest authentication or else
authentication will fail.

Make sure that both values are derived from a common variable
and set default value to 'Nagios4'.